### PR TITLE
Fix drawer documentation link

### DIFF
--- a/views/templates/modules/drawer_part.ejs
+++ b/views/templates/modules/drawer_part.ejs
@@ -10,7 +10,7 @@
         <a class="mdl-navigation__link" href="/downloads">Download</a>
         <a class="mdl-navigation__link" href="mailto:contact@dahliaos.io" target="_blank">Contact</a>
         <a class="mdl-navigation__link" href="https://github.com/orgs/dahliaOS/people" target="_blank">Developers</a>
-        <a class="mdl-navigation__link" href="https://dahliaos.io/docs" target="_blank">Documentation</a>
+        <a class="mdl-navigation__link" href="https://docs.dahliaos.io" target="_blank">Documentation</a>
         <div class="dahliaOS-drawer-separator"></div>
         <span class="mdl-navigation__link" href="">Find us on</span>
         <a class="mdl-navigation__link" href="/discord" target="_blank">Discord</a>


### PR DESCRIPTION
Pressing the "Documentaiton" link in the drawer causes a 404 error.

# Pull request template

* Please make sure you read and fill this template out entirely
* PRs that don't have the template filled out will be ignored

## Description

Pressing the "Documentaiton" link in the drawer causes a 404 error.

Fixes #31

## Screenshots (if appropriate):

## Type of change

Please tick the relevant option by putting an X inside the bracket

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
