### PR TITLE
Fix downloads

### DIFF
--- a/views/downloads.ejs
+++ b/views/downloads.ejs
@@ -173,7 +173,7 @@ limitations under the License.
                             <h6 align="left" class="Roboto mdl-card__supporting-text mdl-card--expand detailsOld">Whats new:</h6>
                             <div class="Roboto mdl-card__supporting-text mdl-card--expand versionDetails">${patchNotes.substring(patchNotes.indexOf('+ ')).replace(/(?:\r\n|\r|\n)/g, '<br>')}</div>
                             <div align="left" class="mdl-card__actions mdl-card--border">
-                                <a href="${data[i].zipball_url} onclick="downloadClicked()"
+                                <a href="${data[i].zipball_url}" onclick="downloadClicked()"
                                     class="Roboto mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
                                     Download
                                 </a>


### PR DESCRIPTION
## Description
Currently, going to https://dahliaos.io/downloads and choosing a build from the older updates fails. For example upon trying to download 200402.1, users are greeted by a page that looks like this: 
![Screenshot from 2021-11-30 23-42-54](https://user-images.githubusercontent.com/32989720/144178499-829dcd10-c4c7-41e3-bc45-0c08421ae5c9.png)
This issue is caused by a missing end quote in the download button which includes the onclick attribute in the redirect url. This pull request fixes the issue by adding a quote to the smallDetails template

## Screenshots (if appropriate):

## Type of change

Please tick the relevant option by putting an X inside the bracket

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
